### PR TITLE
Corrigido: Pasta inexistente img ainda estava no projeto.

### DIFF
--- a/WebHamburgueria.csproj
+++ b/WebHamburgueria.csproj
@@ -300,7 +300,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
-    <Folder Include="img\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Corrigido: Pasta inexistente img ainda estava no projeto.